### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name" : "Spit",
+    "license" : "Artistic-2.0",
     "perl" : "6.c",
     "version" : "0.0.23",
     "description" : "The Spook in the Shell Script (Spit-sh) compiler",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license