### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*.sp linguist-language"Perl 6"
-*.t linguist-language="Perl 6"
+*.sp linguist-language=Perl6
+*.t linguist-language=Perl6


### PR DESCRIPTION
Missing = was a clear error, but I think that using spaces there is
also a problem. Other repos seem to use “Perl6” so that's what I
changed it to.

Without the fix some git commands (e.g. git grep 'blahblah') will print
this warning:

    linguist-language"Perl is not a valid attribute name: .gitattributes:1
    6" is not a valid attribute name: .gitattributes:2