### PR TITLE
Calling rindex on a List comes with a warning

### DIFF
--- a/lib/Spit/Sh/Compiler/Compile-Cmd-And-Call.pm6
+++ b/lib/Spit/Sh/Compiler/Compile-Cmd-And-Call.pm6
@@ -118,7 +118,7 @@ multi method node(SAST::Cmd:D $cmd, :$tight) {
         my $pipe := self.pipe-input($cmd.pipe-in);
         |$pipe,
         # Make a newline if the pipe looks too long
-        ("\\\n$*pad  " if $pipe.substr($pipe.rindex("\n") // 0).chars > $!max-chars-per-line),
+        ("\\\n$*pad  " if $pipe.join(" ").substr($pipe.join(" ").rindex("\n") // 0).chars > $!max-chars-per-line),
         |$cmd.set-env.map({"{.key.subst('-','_',:g)}=",|self.arg(.value)," "}).flat,
         |$full-cmd;
     }


### PR DESCRIPTION
This was changed a few months ago in Raku.  Since `List`s are `Cool`, they get automatically stringified on `Str` methods, such as `substr` and `rindex`.  The latter nowadays warns as it usually indicative of a thinko in the developer's mind.  By adding a explicit `join`, the warning is prevented.  From a performance point of view, there is no difference, as the same `join` would have been done under the hood.