### PR TITLE
Use Metamodel::Primitives over an NQP op

### DIFF
--- a/lib/Spit/Metamodel.pm6
+++ b/lib/Spit/Metamodel.pm6
@@ -158,7 +158,7 @@ class Spit::Metamodel::Parameterizable is Spit::Metamodel::Type {
 
     method new_type(|) {
         my \type = callsame;
-        nqp::setparameterizer(type, -> $, $params is raw {
+        Metamodel::Primitives.set_parameterizer(type, -> $, $params is raw {
             type.^produce-parameterization($params);
         });
         type;


### PR DESCRIPTION
This keeps the module working with upcoming changes to Rakudo (impending merge of `new-disp`).